### PR TITLE
feat: enable 'force-bump-patch-version' and 'changelog-generator-opt' flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ steps:
 | `dry`                                | Do not create a release                                                                | Optional |
 | `prerelease`                         | Flags the release as a prerelease                                                      | Optional |
 | `allow-initial-development-versions` | Starts your initial development release at 0.1.0                                       | Optional |
+| `force-bump-patch-version`           | Increments the patch version if no changes are found                                   | Optional |
+| `changelog-generator-opt`            | Options that are passed to the changelog-generator plugin. Seperated by ","            | Optional |
 
 ## Example `ci.yml` for an npm package
 
@@ -64,6 +66,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           update-file: package.json
+          changelog-generator-opt: "emojis=true"
       - run: npm publish
         if: steps.semrel.outputs.version != ''
         env:

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const exec = require('@actions/exec')
 const tc = require('@actions/tool-cache')
 const SemVer = require('semver/classes/semver')
 
-function getPlatformArch (a, p) {
+function getPlatformArch(a, p) {
   const platform = {
     win32: 'windows'
   }
@@ -17,7 +17,7 @@ function getPlatformArch (a, p) {
   return (platform[p] ? platform[p] : p) + '/' + (arch[a] ? arch[a] : a)
 }
 
-async function installer (version) {
+async function installer(version) {
   core.info(`downloading semantic-release@${version || 'latest'}`)
   const v = version ? `/${version}` : ''
   const path = await tc.downloadTool(`https://get-release.xyz/semantic-release/${getPlatformArch(os.arch(), os.platform())}${v}`)
@@ -25,7 +25,7 @@ async function installer (version) {
   return path
 }
 
-async function main () {
+async function main() {
   try {
     const changelogFile = core.getInput('changelog-file') || '.generated-go-semantic-release-changelog.md'
     const args = ['--version-file', '--changelog', changelogFile]
@@ -48,6 +48,17 @@ async function main () {
     }
     if (core.getInput('allow-initial-development-versions')) {
       args.push('--allow-initial-development-versions')
+    }
+    if (core.getInput('force-bump-patch-version')) {
+      args.push('--force-bump-patch-version')
+    }
+    if (core.getInput('changelog-generator-opt')) {
+      args.push('--changelog-generator-opt')
+      const changelogOpts = core.getInput('changelog-generator-opt').split(",").filter(String)
+      for (let idx = 0; idx < changelogOpts.length; idx++) {
+        args.push('--changelog-generator-opt')
+        args.push(changelogOpts[idx])
+      }
     }
     const binPath = await installer('^2.5.0')
     try {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const exec = require('@actions/exec')
 const tc = require('@actions/tool-cache')
 const SemVer = require('semver/classes/semver')
 
-function getPlatformArch(a, p) {
+function getPlatformArch (a, p) {
   const platform = {
     win32: 'windows'
   }
@@ -17,7 +17,7 @@ function getPlatformArch(a, p) {
   return (platform[p] ? platform[p] : p) + '/' + (arch[a] ? arch[a] : a)
 }
 
-async function installer(version) {
+async function installer (version) {
   core.info(`downloading semantic-release@${version || 'latest'}`)
   const v = version ? `/${version}` : ''
   const path = await tc.downloadTool(`https://get-release.xyz/semantic-release/${getPlatformArch(os.arch(), os.platform())}${v}`)
@@ -25,7 +25,7 @@ async function installer(version) {
   return path
 }
 
-async function main() {
+async function main () {
   try {
     const changelogFile = core.getInput('changelog-file') || '.generated-go-semantic-release-changelog.md'
     const args = ['--version-file', '--changelog', changelogFile]
@@ -54,7 +54,7 @@ async function main() {
     }
     if (core.getInput('changelog-generator-opt')) {
       args.push('--changelog-generator-opt')
-      const changelogOpts = core.getInput('changelog-generator-opt').split(",").filter(String)
+      const changelogOpts = core.getInput('changelog-generator-opt').split(',').filter(String)
       for (let idx = 0; idx < changelogOpts.length; idx++) {
         args.push('--changelog-generator-opt')
         args.push(changelogOpts[idx])

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,6 @@ async function main () {
       args.push('--force-bump-patch-version')
     }
     if (core.getInput('changelog-generator-opt')) {
-      args.push('--changelog-generator-opt')
       const changelogOpts = core.getInput('changelog-generator-opt').split(',').filter(String)
       for (let idx = 0; idx < changelogOpts.length; idx++) {
         args.push('--changelog-generator-opt')


### PR DESCRIPTION
Hi @christophwitzko ,

Last but not least! This is the **final** PR in order to enable the GitHub Action to use the `force-bump-patch-version` flag and also provide `changelog-generator-opt` configuration.

Let me know if my changes suit your expectations. 😄 

Cheers
Timo