### PR TITLE
fix(action): use .version-unreleased if dry was used

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,8 +71,9 @@ async function main () {
       return
     }
     const generatedChangelog = (await fs.readFile(changelogFile)).toString('utf8')
-    const version = (await fs.readFile('.version')).toString('utf8')
-    await fs.unlink('.version')
+    const versionFilename = (core.getInput('dry')) ? '.version-unreleased' : '.version'
+    const version = (await fs.readFile(versionFilename)).toString('utf8')
+    await fs.unlink(versionFilename)
     const parsedVersion = new SemVer(version)
     core.setOutput('changelog', generatedChangelog)
     core.debug(`setting version to ${parsedVersion.version}`)


### PR DESCRIPTION
Fixes https://github.com/go-semantic-release/action/pull/16
Please release a fix.