### PR TITLE
chore: add action info of force-bump-patch-version and changelog-generator-opt

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,12 @@ inputs:
   allow-initial-development-versions:
     description: 'starts your initial development release at 0.1.0'
     required: false
+  force-bump-patch-version:
+    description: 'increments the patch version if no changes are found'
+    required: false
+  changelog-generator-opt:
+    description: 'options that are passed to the changelog-generator plugin'
+    required: false
 outputs:
   version:
     description: 'the version of the created release'


### PR DESCRIPTION
Hi @christophwitzko ,

I noticed that the GitHub action always complains if you provide config inputs which are not yet part of `action.yml`. 
![image](https://user-images.githubusercontent.com/11437666/105815315-03a71b80-5fb3-11eb-8f5b-6e8b3b03d3ac.png)

It seems that I forgot to put the that when I introduced the new fields:

- `force-bump-patch-version`
- `changelog-generator-opt`

Therefore my small and simple PR to get rid of this warning :)

Regards
Timo