### PR TITLE
Update action to use node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-node@v1
           with:
-            node-version: 16
+            node-version: 20
         - run: npm ci
         - run: npm test
         - run: npm run build

--- a/action.yml
+++ b/action.yml
@@ -57,5 +57,5 @@ outputs:
   changelog:
     description: 'the generated release changelog'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
This PR Aims to update the action and ci to use node 20 instead of deprecated node 16. 

Please let me know if I missed something.


There seems to be no BREAKING CHANGES when updating to node 20 therefore I opted to set this as a fix instead. let me know if you prefer marking this update as a breaking change. 