### PR TITLE
fix: use getBooleanInput to determine versionFilename

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ async function main (): Promise<void> {
       return
     }
     const generatedChangelog = (await fs.readFile(changelogFile)).toString('utf8')
-    const versionFilename = (core.getInput('dry')) ? '.version-unreleased' : '.version'
+    const versionFilename = (core.getBooleanInput('dry')) ? '.version-unreleased' : '.version'
     const version = (await fs.readFile(versionFilename)).toString('utf8')
     await fs.unlink(versionFilename)
     const parsedVersion = new SemVer(version)


### PR DESCRIPTION
Fixes #36.

When a user set `dry: false`, the code would incorrectly set `versionFilename = .version-unreleased` because `core.getInput` returns a string and `"false"` is truthy in Javascript.

Instead, let's use `getBooleanInput` which already exists in this file -- to convert the string to a bool.